### PR TITLE
bed annotation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,10 @@ jobs:
         experimental: [false]
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Cache Qt
         id: cache-qt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/fast-cpp-csv-parser"]
+	path = thirdparty/fast-cpp-csv-parser
+	url = https://github.com/ben-strasser/fast-cpp-csv-parser

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LIB_SOURCES
         graph/assemblygraph.cpp
         graph/assemblygraphfast.cpp
         graph/annotationsmanager.cpp
+        graph/bedloader.cpp
         graph/debruijnedge.cpp
         graph/debruijnnode.cpp
         graph/graphicsitemedge.cpp
@@ -77,6 +78,7 @@ set(LIB_SOURCES
         program/settings.cpp
         ui/aboutdialog.cpp
         ui/annotationswidget.cpp
+        ui/bedwidget.cpp
         ui/blasthitfiltersdialog.cpp
         ui/blastsearchdialog.cpp
         ui/changenodedepthdialog.cpp

--- a/graph/assemblygraph.h
+++ b/graph/assemblygraph.h
@@ -31,6 +31,7 @@
 #include "ogdf/basic/Graph.h"
 #include "ogdf/basic/GraphAttributes.h"
 #include "blast/blasthit.h"
+#include "annotation.hpp"
 
 #include <QString>
 #include <QMap>

--- a/graph/bedloader.cpp
+++ b/graph/bedloader.cpp
@@ -1,5 +1,10 @@
 #include "bedloader.hpp"
 
+#include <sstream>
+
+#include <fast-cpp-csv-parser/csv.h>
+
+
 namespace bed {
 
 std::vector<int64_t> parseIntArray(const std::string &intArrayString) {

--- a/graph/bedloader.cpp
+++ b/graph/bedloader.cpp
@@ -1,0 +1,72 @@
+#include "bedloader.hpp"
+
+namespace bed {
+
+std::vector<int64_t> parseIntArray(const std::string &intArrayString) {
+    std::stringstream ss{intArrayString};
+    std::string intString;
+    std::vector<int64_t> res;
+    while (std::getline(ss, intString, ',')) {
+        if (intString.empty()) {
+            break;
+        }
+        res.push_back(std::stoll(intString));
+    }
+    return res;
+}
+
+/* TODO: 1) add assertions
+ *       2) support custom fields ?
+ *       3) make better error handling
+ */
+std::vector<Line> load(const std::filesystem::path &path) {
+    io::CSVReader<12,
+                  io::trim_chars<' '>,
+                  io::no_quote_escape<'\t'>,
+                  io::throw_on_overflow,
+                  io::single_and_empty_line_comment<'#'>> csvReader(path);
+    std::vector<Line> res;
+    Line bedLine;
+    char strandChar = '.';
+    std::string itemRgbString;
+    int64_t blockCount = 0;
+    std::string blockSizesString;
+    std::string blockStartsString;
+    while (csvReader.read_row(bedLine.chrom,
+                              bedLine.chromStart,
+                              bedLine.chromEnd,
+                              bedLine.name,
+                              bedLine.score,
+                              strandChar,
+                              bedLine.thickStart,
+                              bedLine.thickEnd,
+                              itemRgbString,
+                              blockCount,
+                              blockSizesString,
+                              blockStartsString)) {
+        bedLine.strand = Strand{strandChar};
+        if (bedLine.thickStart == -1 || bedLine.thickEnd == -1) {
+            bedLine.thickStart = bedLine.chromStart;
+            bedLine.thickEnd = bedLine.chromEnd;
+        }
+        if (itemRgbString != "0") {
+            auto rgbArray = parseIntArray(itemRgbString);
+            bedLine.itemRgb.r = rgbArray[0];
+            bedLine.itemRgb.g = rgbArray[1];
+            bedLine.itemRgb.b = rgbArray[2];
+        }
+        if (blockCount != 0) {
+            auto blockSizes = parseIntArray(blockSizesString);
+            auto blockStarts = parseIntArray(blockStartsString);
+            for (int i = 0; i < blockCount; i++) {
+                auto blockStart = bedLine.chromStart + blockStarts[i];
+                auto blockEnd = blockStart + blockSizes[i];
+                bedLine.blocks.push_back(Block{.start = blockStart, .end = blockEnd});
+            }
+        }
+        res.emplace_back(bedLine);
+    }
+    return res;
+}
+
+}

--- a/graph/bedloader.hpp
+++ b/graph/bedloader.hpp
@@ -1,0 +1,52 @@
+#ifndef BANDAGE_GRAPH_BEDLOADER_HPP_
+#define BANDAGE_GRAPH_BEDLOADER_HPP_
+
+#include <string>
+#include <vector>
+#include <filesystem>
+
+#include <fast-cpp-csv-parser/csv.h>
+#include <QColor>
+
+namespace bed {
+
+enum class Strand : char {
+    UNKNOWN = '.',
+    NORMAL = '+',
+    REVERSE_COMPLEMENT = '-', // ?? maybe simple complement or simple reverse
+};
+
+struct ItemRgb {
+    uint8_t r = 0;
+    uint8_t g = 0;
+    uint8_t b = 0;
+
+    QColor toQColor() const {
+        return {r, g, b};
+    }
+};
+
+struct Block {
+    int64_t start, end;
+};
+
+struct Line {
+    std::string chrom{};
+    int64_t chromStart = 0;
+    int64_t chromEnd = 0;
+    std::string name{};
+    int score = 0;
+    Strand strand = Strand::UNKNOWN;
+    int64_t thickStart = -1;
+    int64_t thickEnd = -1;
+    ItemRgb itemRgb{};
+    std::vector<Block> blocks{};
+};
+
+std::vector<int64_t> parseIntArray(const std::string &intArrayString);
+
+std::vector<Line> load(const std::filesystem::path &path);
+
+}
+
+#endif //BANDAGE_GRAPH_BEDLOADER_HPP_

--- a/graph/bedloader.hpp
+++ b/graph/bedloader.hpp
@@ -5,7 +5,6 @@
 #include <vector>
 #include <filesystem>
 
-#include <fast-cpp-csv-parser/csv.h>
 #include <QColor>
 
 namespace bed {

--- a/program/settings.cpp
+++ b/program/settings.cpp
@@ -138,6 +138,7 @@ Settings::Settings()
     blastEValueFilter = SciNotSetting(SciNot(1.0, -10), SciNot(1.0, -999), SciNot(9.9, 1), false);
     blastBitScoreFilter = FloatSetting(1000.0, 0.0, 1000000.0, false);
     blastAnnotationGroupName = "Blast Hits";
+    bedAnnotationGroupName = "BED";
 
     minDepthRange = FloatSetting(10.0, 0.0, 1000000.0);
     maxDepthRange = FloatSetting(100.0, 0.0, 1000000.0);

--- a/program/settings.h
+++ b/program/settings.h
@@ -119,6 +119,7 @@ public:
     QString csvFilename;
     QString unnamedQueryDefaultName;
     QString blastAnnotationGroupName;
+    QString bedAnnotationGroupName;
 
     double minZoom;
     double minZoomOnGraphDraw;

--- a/ui/bedwidget.cpp
+++ b/ui/bedwidget.cpp
@@ -9,6 +9,12 @@
 #include "graph/annotationsmanager.hpp"
 #include "graph/assemblygraph.h"
 
+
+inline constexpr double BED_MAIN_WIDTH = 1;
+inline constexpr double BED_THICK_WIDTH = 1.3;
+inline constexpr double BED_BLOCK_WIDTH = 1.6;
+
+
 BedWidget::BedWidget(QWidget *parent) : QWidget(parent) {
     static const QString label = "Load BED file";
     auto *button = new QPushButton(label, this);
@@ -28,9 +34,9 @@ BedWidget::BedWidget(QWidget *parent) : QWidget(parent) {
             if (it != g_assemblyGraph->m_deBruijnGraphNodes.end()) {
                 auto &annotation = annotationGroup.annotationMap[it.value()].emplace_back(
                         std::make_unique<Annotation>(bedLine.chromStart, bedLine.chromEnd, bedLine.name));
-                annotation->addView(std::make_unique<SolidView>(1, bedLine.itemRgb.toQColor()));
-                annotation->addView(std::make_unique<BedThickView>(1.2, bedLine.itemRgb.toQColor(), bedLine.thickStart, bedLine.thickEnd));
-                annotation->addView(std::make_unique<BedBlockView>(1.4, bedLine.itemRgb.toQColor(), bedLine.blocks));
+                annotation->addView(std::make_unique<SolidView>(BED_MAIN_WIDTH, bedLine.itemRgb.toQColor()));
+                annotation->addView(std::make_unique<BedThickView>(BED_THICK_WIDTH, bedLine.itemRgb.toQColor(), bedLine.thickStart, bedLine.thickEnd));
+                annotation->addView(std::make_unique<BedBlockView>(BED_BLOCK_WIDTH, bedLine.itemRgb.toQColor(), bedLine.blocks));
             }
         }
     });

--- a/ui/bedwidget.cpp
+++ b/ui/bedwidget.cpp
@@ -1,0 +1,39 @@
+#include "bedwidget.h"
+
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QFileDialog>
+
+#include "program/memory.h"
+#include "graph/bedloader.hpp"
+#include "graph/annotationsmanager.hpp"
+#include "graph/assemblygraph.h"
+
+BedWidget::BedWidget(QWidget *parent) : QWidget(parent) {
+    static const QString label = "Load BED file";
+    auto *button = new QPushButton(label, this);
+
+    auto *layout = new QVBoxLayout();
+    layout->addWidget(button);
+
+    connect(button, &QPushButton::clicked, [this]() {
+        g_annotationsManager->removeGroupByName(g_settings->bedAnnotationGroupName);
+        QString bedFileName = QFileDialog::getOpenFileName(this, label, g_memory->rememberedPath);
+        if (bedFileName.isNull()) return;
+        auto bedLines = bed::load(bedFileName.toStdString());
+        auto &annotationGroup = g_annotationsManager->createAnnotationGroup(g_settings->bedAnnotationGroupName);
+        for (const auto &bedLine : bedLines) {
+            auto nodeName = bedLine.chrom + (bedLine.strand == bed::Strand::REVERSE_COMPLEMENT ? "-" : "+");
+            auto it = g_assemblyGraph->m_deBruijnGraphNodes.find(nodeName);
+            if (it != g_assemblyGraph->m_deBruijnGraphNodes.end()) {
+                auto &annotation = annotationGroup.annotationMap[it.value()].emplace_back(
+                        std::make_unique<Annotation>(bedLine.chromStart, bedLine.chromEnd, bedLine.name));
+                annotation->addView(std::make_unique<SolidView>(1, bedLine.itemRgb.toQColor()));
+                annotation->addView(std::make_unique<BedThickView>(1.2, bedLine.itemRgb.toQColor(), bedLine.thickStart, bedLine.thickEnd));
+                annotation->addView(std::make_unique<BedBlockView>(1.4, bedLine.itemRgb.toQColor(), bedLine.blocks));
+            }
+        }
+    });
+
+    setLayout(layout);
+}

--- a/ui/bedwidget.h
+++ b/ui/bedwidget.h
@@ -1,0 +1,16 @@
+#ifndef BANDAGENG_BEDWIDGET_H
+#define BANDAGENG_BEDWIDGET_H
+
+
+#include <QWidget>
+
+
+class BedWidget : public QWidget {
+public:
+    BedWidget(QWidget *parent);
+
+
+};
+
+
+#endif //BANDAGENG_BEDWIDGET_H

--- a/ui/bedwidget.h
+++ b/ui/bedwidget.h
@@ -7,9 +7,7 @@
 
 class BedWidget : public QWidget {
 public:
-    BedWidget(QWidget *parent);
-
-
+    explicit BedWidget(QWidget *parent);
 };
 
 

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -1440,65 +1440,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QWidget" name="annotationSelectorWidget" native="true">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <layout class="QVBoxLayout" name="annotationsVBoxLayout">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="nodeLabelsG_5">
-             <property name="font">
-              <font>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Annotations</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="Line" name="line_11">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item><item>
-        <spacer name="verticalSpacer_8">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>229</width>
-           <height>15</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-        <item>
-         <widget class="AnnotationsListWidget" name="annotationsListWidget" native="true"/>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_7">
+         <spacer name="verticalSpacer_8">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -1536,7 +1478,7 @@
          <widget class="BedWidget" name="bedWidget" native="true"/>
         </item>
         <item>
-         <spacer name="verticalSpacer_8">
+         <spacer name="verticalSpacer_9">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -1591,7 +1533,7 @@
           </layout>
          </widget>
         </item><item>
-        <spacer name="verticalSpacer_9">
+        <spacer name="verticalSpacer_10">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -1498,6 +1498,118 @@
          <widget class="AnnotationsListWidget" name="annotationsListWidget" native="true"/>
         </item>
         <item>
+         <spacer name="verticalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>229</width>
+            <height>15</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="nodeLabelsG_5">
+          <property name="font">
+           <font>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>BED</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Line" name="line_11">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="BedWidget" name="bedWidget" native="true"/>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>229</width>
+            <height>15</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QWidget" name="annotationSelectorWidget" native="true">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <layout class="QVBoxLayout" name="annotationsVBoxLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="nodeLabelsG_6">
+             <property name="font">
+              <font>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Annotations</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Line" name="line_12">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item><item>
+        <spacer name="verticalSpacer_9">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>229</width>
+           <height>15</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+        <item>
+         <widget class="AnnotationsListWidget" name="annotationsListWidget" native="true"/>
+        </item>
+        <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -2660,6 +2772,12 @@
    <class>AnnotationsListWidget</class>
    <extends>QListWidget</extends>
    <header>annotationswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>BedWidget</class>
+   <extends>QWidget</extends>
+   <header>bedwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
resolving issue https://github.com/asl/Bandage/issues/22

can be merged after https://github.com/asl/Bandage/pull/29

Added support of the following BED features:
- draw annotation from `chromStart` to `chromEnd`
- use `color` from .bed file.
- annotate node or reverse-complement node according to the `strand` field. 

```
test.gfa:
S	10559427	<sequence with length 2856>
```

```
test.bed:
10559427	1000	2000	test	10	+
```

![image](https://user-images.githubusercontent.com/28672835/167313569-3a6f557f-a2ef-4e03-b3d4-27e97375c0f2.png)

![image](https://user-images.githubusercontent.com/28672835/167313600-94aef510-6676-4ec5-bf5f-0cbd1cf8f2cf.png)

![image](https://user-images.githubusercontent.com/28672835/167313628-f6ef98a9-f37e-41d6-abec-24691b9aa359.png)

![image](https://user-images.githubusercontent.com/28672835/167313645-d9b28b34-e209-45f5-91f9-045ee992a58d.png)
