### PR TITLE
Allow path names in CSV data

### DIFF
--- a/graph/nodecolorer.cpp
+++ b/graph/nodecolorer.cpp
@@ -239,8 +239,9 @@ QColor CSVNodeColorer::get(const GraphicsItemNode *node) {
 }
 
 void CSVNodeColorer::reset() {
-    size_t columns = m_graph->m_csvHeaders.size();
+    m_colors.clear();
 
+    size_t columns = m_graph->m_csvHeaders.size();
     m_colors.resize(columns);
     // Store all unique values into a map
     for (const auto &entry : m_graph->m_nodeCSVData) {

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -281,6 +281,8 @@ void MainWindow::cleanUp()
     ui->csvComboBox->clear();
     ui->csvComboBox->setEnabled(false);
     g_settings->displayNodeCsvDataCol = 0;
+
+    switchColourScheme(RANDOM_COLOURS);
 }
 
 void MainWindow::loadCSV(QString fullFileName)
@@ -1481,6 +1483,7 @@ void MainWindow::openSettingsDialog() {
 
     g_assemblyGraph->recalculateAllNodeWidths();
     g_graphicsView->setAntialiasing(g_settings->antialiasing);
+    g_settings->nodeColorer->reset();
 
     resetAllNodeColours();
 }


### PR DESCRIPTION
This allows e.g. to color MAGs if the graph contains paths (scaffold) and they were binned.

<img width="1577" alt="Screenshot 2022-06-13 at 16 29 33" src="https://user-images.githubusercontent.com/67392/173383086-74124943-27e7-4cdd-bda5-6ee453236b63.png">
