### PR TITLE
Iterative graph walk rework

### DIFF
--- a/graph/assemblygraph.cpp
+++ b/graph/assemblygraph.cpp
@@ -588,7 +588,7 @@ void AssemblyGraph::markNodesToDraw(const std::vector<DeBruijnNode *>& startingN
 
             node->setAsDrawn();
             node->setAsSpecial();
-            node->labelNeighbouringNodesAsDrawn(nodeDistance, nullptr);
+            node->labelNeighbouringNodesAsDrawn(nodeDistance);
         }
     }
 

--- a/graph/debruijnnode.h
+++ b/graph/debruijnnode.h
@@ -108,7 +108,7 @@ public:
     void addEdge(DeBruijnEdge * edge);
     void removeEdge(DeBruijnEdge * edge);
     void determineContiguity();
-    void labelNeighbouringNodesAsDrawn(int nodeDistance, DeBruijnNode * callingNode);
+    void labelNeighbouringNodesAsDrawn(int nodeDistance);
     void setDepth(double newDepth) {m_depth = newDepth;}
     void setName(QString newName) {m_name = std::move(newName);}
 


### PR DESCRIPTION
The function labelNeighbouringNodesAsDrawn now works iteratively and does not need the second argument callingNode.