### PR TITLE
Put GraphicsItemEdge on diet: do not store things that are calculated

### DIFF
--- a/graph/graphicsitemedge.h
+++ b/graph/graphicsitemedge.h
@@ -25,29 +25,19 @@
 
 class DeBruijnEdge;
 
-class GraphicsItemEdge : public QGraphicsPathItem
-{
+class GraphicsItemEdge : public QGraphicsPathItem {
 public:
     explicit GraphicsItemEdge(DeBruijnEdge * deBruijnEdge, QGraphicsItem * parent = nullptr);
 
-    DeBruijnEdge * m_deBruijnEdge;
-    QPointF m_startingLocation;
-    QPointF m_endingLocation;
-    QPointF m_beforeStartingLocation;
-    QPointF m_afterEndingLocation;
-    QPointF m_controlPoint1;
-    QPointF m_controlPoint2;
-    QColor m_edgeColor;
-    Qt::PenStyle m_penStyle;
-
     void paint(QPainter * painter, const QStyleOptionGraphicsItem *, QWidget *) override;
     QPainterPath shape() const override;
-    void calculateAndSetPath();
-    void setControlPointLocations();
-    void setStartingPoints(QPointF startingLocation, QPointF beforeStartingLocation) {m_startingLocation = startingLocation; m_beforeStartingLocation = beforeStartingLocation;}
-    void setEndingPoints(QPointF endingLocation, QPointF afterEndingLocation) {m_endingLocation = endingLocation; m_afterEndingLocation = afterEndingLocation;}
-    void makeSpecialPathConnectingNodeToSelf();
-    void makeSpecialPathConnectingNodeToReverseComplement();
+
+    void remakePath();
+    DeBruijnEdge *edge() const { return m_deBruijnEdge; }
+private:
+    DeBruijnEdge *m_deBruijnEdge;
+    QColor m_edgeColor;
+    Qt::PenStyle m_penStyle;
 };
 
 #endif // GRAPHICSITEMEDGE_H

--- a/graph/graphicsitemnode.cpp
+++ b/graph/graphicsitemnode.cpp
@@ -395,44 +395,34 @@ void GraphicsItemNode::mouseMoveEvent(QGraphicsSceneMouseEvent * event)
 }
 
 
-//This function remakes edge paths.  If nodes is passed, it will remake the
-//edge paths for all of the nodes.  If nodes isn't passed, then it will just
-//do it for this node.
-void GraphicsItemNode::fixEdgePaths(std::vector<GraphicsItemNode *> * nodes) const
-{
+// This function remakes edge paths.  If nodes is passed, it will remake the
+// edge paths for all of the nodes.  If nodes isn't passed, then it will just
+// do it for this node.
+void GraphicsItemNode::fixEdgePaths(std::vector<GraphicsItemNode *> * nodes) const {
     std::set<DeBruijnEdge *> edgesToFix;
 
-    if (nodes == nullptr)
-    {
+    if (nodes == nullptr) {
         for (auto *edge : m_deBruijnNode->edges())
             edgesToFix.insert(edge);
-    }
-    else
-    {
-        for (auto &graphicNode : *nodes)
-        {
+    } else {
+        for (auto &graphicNode : *nodes) {
             DeBruijnNode * node = graphicNode->m_deBruijnNode;
             for (auto *edge : node->edges())
                 edgesToFix.insert(edge);
         }
     }
 
-    for (auto *deBruijnEdge : edgesToFix)
-    {
-        GraphicsItemEdge * graphicsItemEdge = deBruijnEdge->getGraphicsItemEdge();
-
+    for (auto *deBruijnEdge : edgesToFix) {
         //If this edge has a graphics item, adjust it now.
-        if (graphicsItemEdge != nullptr)
-            graphicsItemEdge->calculateAndSetPath();
+        if (GraphicsItemEdge *graphicsItemEdge = deBruijnEdge->getGraphicsItemEdge())
+            graphicsItemEdge->remakePath();
 
         // If this edge does not have a graphics item, then perhaps its
         // reverse complement does.  Only do this check if the graph was drawn
         // on single mode.
-        else if (!g_settings->doubleMode)
-        {
-            graphicsItemEdge = deBruijnEdge->getReverseComplement()->getGraphicsItemEdge();
-            if (graphicsItemEdge != nullptr)
-                graphicsItemEdge->calculateAndSetPath();
+        else if (!g_settings->doubleMode) {
+            if (GraphicsItemEdge *graphicsItemEdge = deBruijnEdge->getReverseComplement()->getGraphicsItemEdge())
+                graphicsItemEdge->remakePath();
         }
     }
 }

--- a/graph/graphicsitemnode.h
+++ b/graph/graphicsitemnode.h
@@ -69,9 +69,9 @@ public:
     void shiftPoints(QPointF difference);
     void remakePath();
     bool usePositiveNodeColour() const;
-    QPointF getFirst() const {return m_linePoints[0];}
+    QPointF getFirst() const {return m_linePoints.front();}
     QPointF getSecond() const {return m_linePoints[1];}
-    QPointF getLast() const {return m_linePoints[m_linePoints.size()-1];}
+    QPointF getLast() const {return m_linePoints.back();}
     QPointF getSecondLast() const {return m_linePoints[m_linePoints.size()-2];}
     std::vector<QPointF> getCentres() const;
     void setNodeColour(QColor color) { m_colour = color; }

--- a/tests/bandagetests.cpp
+++ b/tests/bandagetests.cpp
@@ -19,6 +19,8 @@
 #include "graph/assemblygraph.h"
 #include "graph/debruijnnode.h"
 #include "graph/debruijnedge.h"
+#include "graph/graphicsitemedge.h"
+#include "graph/graphicsitemnode.h"
 #include "graph/annotationsmanager.h"
 #include "graph/gfawriter.h"
 #include "graph/io.h"
@@ -79,6 +81,8 @@ public:
             : m_tmpDir("bandage-tests") {
         std::cout << "sizeof(DeBruijnNode)=" << sizeof(DeBruijnNode)
                   << ", sizeof(DeBruijnEdge)=" << sizeof(DeBruijnEdge) << std::endl;
+        std::cout << "sizeof(GraphicsItemEdge)=" << sizeof(GraphicsItemEdge)
+                  << ", sizeof(GraphicsItemNode)=" << sizeof(GraphicsItemNode) << std::endl;
     }
 
 private slots:

--- a/ui/bandagegraphicsscene.cpp
+++ b/ui/bandagegraphicsscene.cpp
@@ -97,7 +97,7 @@ std::vector<DeBruijnEdge *> BandageGraphicsScene::getSelectedEdges() {
 
     for (auto *selectedItem : selectedItems())
         if (auto * selectedEdgeItem = dynamic_cast<GraphicsItemEdge *>(selectedItem))
-            returnVector.push_back(selectedEdgeItem->m_deBruijnEdge);
+            returnVector.push_back(selectedEdgeItem->edge());
 
     return returnVector;
 }


### PR DESCRIPTION
This reduces the size of GraphicsItemEdge from 144 bytes to just 48