### PR TITLE
Add rd depth tag from hifiasm

### DIFF
--- a/graph/assemblygraphbuilder.cpp
+++ b/graph/assemblygraphbuilder.cpp
@@ -425,7 +425,7 @@ namespace io {
                 nodeDepth = *kaTag;
             } else if (auto rdTag = gfa::getTag<int64_t>("rd", record.tags)) {
                 graph.m_depthTag = "rd";
-                nodeDepth = *rdTag;
+                nodeDepth = *rdTag + 1;
             } else if (auto kcTag = gfa::getTag<int64_t>("KC", record.tags)) {
                 graph.m_depthTag = "KC";
                 nodeDepth = double(*kcTag) / double(length);

--- a/graph/assemblygraphbuilder.cpp
+++ b/graph/assemblygraphbuilder.cpp
@@ -217,6 +217,7 @@ static bool isStandardGFATag(const char name[2]) {
         case makeGFATag("FC"):
         case makeGFATag("RC"):
         case makeGFATag("ka"):
+        case makeGFATag("rd"):
         case makeGFATag("LB"):
         case makeGFATag("L2"):
         case makeGFATag("CB"):
@@ -422,6 +423,9 @@ namespace io {
             } else if (auto kaTag = gfa::getTag<float>("ka", record.tags)) {
                 graph.m_depthTag = "ka";
                 nodeDepth = *kaTag;
+            } else if (auto rdTag = gfa::getTag<int64_t>("rd", record.tags)) {
+                graph.m_depthTag = "rd";
+                nodeDepth = *rdTag;
             } else if (auto kcTag = gfa::getTag<int64_t>("KC", record.tags)) {
                 graph.m_depthTag = "KC";
                 nodeDepth = double(*kcTag) / double(length);

--- a/graph/gfawriter.cpp
+++ b/graph/gfawriter.cpp
@@ -72,7 +72,7 @@ namespace gfa {
         if (depthTag == "DP" || depthTag == "dp")
             gfaSegmentLine += "\tDP:f:" + QString::number(node->getDepth()).toLatin1();
         else if (depthTag == "rd")
-            gfaSegmentLine += "\trd:i:" + QString::number(node->getDepth()).toLatin1();
+            gfaSegmentLine += "\trd:i:" + QString::number(node->getDepth()-1).toLatin1();
         else if (depthTag == "KC" || depthTag == "RC" || depthTag == "FC")
             gfaSegmentLine += "\t" + depthTag.toLatin1() + ":i:" +
                               QString::number(int(node->getDepth() * gfaSequence.length() + 0.5)).toLatin1();

--- a/graph/gfawriter.cpp
+++ b/graph/gfawriter.cpp
@@ -71,6 +71,8 @@ namespace gfa {
         //information and so we don't save depth.
         if (depthTag == "DP" || depthTag == "dp")
             gfaSegmentLine += "\tDP:f:" + QString::number(node->getDepth()).toLatin1();
+        else if (depthTag == "rd")
+            gfaSegmentLine += "\trd:i:" + QString::number(node->getDepth()).toLatin1();
         else if (depthTag == "KC" || depthTag == "RC" || depthTag == "FC")
             gfaSegmentLine += "\t" + depthTag.toLatin1() + ":i:" +
                               QString::number(int(node->getDepth() * gfaSequence.length() + 0.5)).toLatin1();


### PR DESCRIPTION
rd:i:n means that n+1 reads were used to construct the node. I decided to show the raw rd value instead of adding 1 to it.